### PR TITLE
Create packages-temp.json in user writable path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for luxtorpeda-dev
 
+### 22.0 (2020-09-02)
+
+* [ZeroPointEnergy] Fix path of packages-temp.json when downloading the packages.json
+
 ### 21.0 (2020-08-29)
 
 * Changed location of packages.json to ~/.cache/luxtorpeda/packages.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "luxtorpeda"
-version = "21.0.0"
+version = "22.0.0"
 dependencies = [
  "bzip2 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luxtorpeda"
-version = "21.0.0"
+version = "22.0.0"
 authors = ["Patryk Obara <dreamer.tan@gmail.com>", "d10sfan <d10sfan+luxtorpeda@gmail.com>"]
 edition = "2018"
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -173,7 +173,7 @@ pub fn update_packages_json() -> io::Result<()> {
         
         let remote_packages_url = std::format!("{0}/packages.json", &config_parsed["host_url"]);
         let mut download_complete = false;
-        let local_packages_temp_path = user_env::tool_dir().join("packages-temp.json");
+        let local_packages_temp_path = path_to_packages_file().with_file_name("packages-temp.json");
         
         match reqwest::blocking::get(&remote_packages_url) {
             Ok(mut response) => {


### PR DESCRIPTION
This is related to issue #41 . Luxtorpeda was still crashing with permission denied because it attempted to write the packages-temp.json file into the tools directory. This patch fixes it.