### PR TITLE
update sha-1 to 0.9.8 to get rid of unmaintained dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,12 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,7 +958,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "sha-1 0.9.1",
+ "sha-1 0.9.8",
  "signal-hook",
  "steamlocate",
  "steamy-controller",
@@ -1611,13 +1605,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.9",
- "cpuid-bool",
+ "cfg-if 1.0.0",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]


### PR DESCRIPTION
Older versions of `sha-1` still use the crate `cpuid-bool`, but that crate is unmaintained (RUSTSEC-2021-0064). Newer `sha-1` versions do not depend on `cpuid-bool` anymore.

See <https://rustsec.org/advisories/RUSTSEC-2021-0064> for more information.

This PR eliminates one warning from `cargo audit`.

### Luxtorpeda Client Submissions

* [x] Have you verified that the code changes in the pull request are related to only the items you wish to change?
* [ ] Have you run the build locally and ensured the changes allowed you to launch and play the Steam game?
* [x] Have you ensured that there is not already a pull request or active feature for the one you are adding?
