### PR TITLE
Workaround for dpi scaling calculation with high refresh rate & update to rust 1.63

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     container:
-      image: rust:1.60-buster
+      image: rust:1.63-buster
     env:
       CARGO_HOME: ./cargo
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.60-buster
+      image: rust:1.63-buster
     env:
       CARGO_HOME: ./cargo
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Packages changelog can be seen at https://github.com/luxtorpeda-dev/packages/blob/master/CHANGELOG.md
 
+### 58.0 (2022-08-31)
+
+* Workaround for dpi scaling calculation with high refresh rate
+* Update to rust 1.63
+
 ### 57.0 (2022-08-15)
 
 * [ThibaultLemaire] Show gui message on cross filesystem access

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "luxtorpeda"
-version = "57.0.0"
+version = "58.0.0"
 dependencies = [
  "bzip2",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "egui_sdl2_gl"
 version = "0.16.0"
-source = "git+https://github.com/luxtorpeda-dev/egui_sdl2_gl.git?rev=e3b51fb#e3b51fbde73593e739aaf9df02aa8f658b54e2ac"
+source = "git+https://github.com/luxtorpeda-dev/egui_sdl2_gl.git?rev=09ebb14#09ebb141ca563980910fee981b11fc0ddb3e6e66"
 dependencies = [
  "egui",
  "gl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.19.2", default-features = false, features = ["full"] }
 which = "4.2.5"
 steamlocate = { git = "https://github.com/luxtorpeda-dev/steamlocate-rs", tag = "0.1.5" }
 egui = "0.16.1"
-egui_sdl2_gl =  { git = "https://github.com/luxtorpeda-dev/egui_sdl2_gl.git", "rev" = "e3b51fb", features = ["sdl2_image"] }
+egui_sdl2_gl =  { git = "https://github.com/luxtorpeda-dev/egui_sdl2_gl.git", "rev" = "09ebb14", features = ["sdl2_image"] }
 image = "0.24.2"
 signal-hook = "0.3.14"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "luxtorpeda"
-version = "57.0.0"
+version = "58.0.0"
 authors = ["Patryk Obara <dreamer.tan@gmail.com>", "d10sfan <d10sfan+luxtorpeda@gmail.com>"]
 edition = "2021"
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -645,8 +645,12 @@ pub fn start_egui_window(
     }
 
     let shader_ver = ShaderVersion::Default;
-    let (painter, egui_state) =
-        egui_backend::with_sdl2(&window, shader_ver, DpiScaling::Custom(dpi_scaling), using_dpi);
+    let (painter, egui_state) = egui_backend::with_sdl2(
+        &window,
+        shader_ver,
+        DpiScaling::Custom(dpi_scaling),
+        using_dpi,
+    );
     let start_time = Instant::now();
     Ok((
         EguiWindowInstance {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -53,7 +53,7 @@ pub const SCROLL_TIMES: usize = 40_usize;
 pub const AXIS_DEAD_ZONE: i16 = 10_000;
 pub const SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR: &str = "SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR";
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum RequestedAction {
     Confirm,
     Back,
@@ -80,7 +80,7 @@ impl Display for ControllerType {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum ControllerType {
     Xbox,
     DualShock,
@@ -135,7 +135,7 @@ impl EguiWindowInstance {
                             last_axis_timestamp = Instant::now();
                         } else if last_axis_timestamp.elapsed().as_millis() >= 300
                             && last_input_timestamp.elapsed().as_millis() >= 300
-                            && (axis_value > AXIS_DEAD_ZONE || axis_value < -AXIS_DEAD_ZONE)
+                            && !(-AXIS_DEAD_ZONE..=AXIS_DEAD_ZONE).contains(&axis_value)
                         {
                             last_axis_timestamp = Instant::now();
                             last_input_timestamp = Instant::now();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -441,9 +441,12 @@ pub fn start_egui_window(
         "window is on display_index: {:?} on_steam_deck: {} steam_deck_gaming_mode: {}",
         display_index, on_steam_deck, steam_deck_gaming_mode
     );
+
+    let mut using_dpi = 0_f32;
+
     match video_subsystem.display_dpi(display_index) {
         Ok(dpi) => {
-            let mut using_dpi = dpi.0;
+            using_dpi = dpi.0;
 
             if dpi.1 > using_dpi {
                 using_dpi = dpi.1;
@@ -643,7 +646,7 @@ pub fn start_egui_window(
 
     let shader_ver = ShaderVersion::Default;
     let (painter, egui_state) =
-        egui_backend::with_sdl2(&window, shader_ver, DpiScaling::Custom(dpi_scaling));
+        egui_backend::with_sdl2(&window, shader_ver, DpiScaling::Custom(dpi_scaling), using_dpi);
     let start_time = Instant::now();
     Ok((
         EguiWindowInstance {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -473,6 +473,10 @@ pub fn start_egui_window(
                 using_dpi /= 2_f32;
             }
 
+            if using_dpi >= 1250.0 {
+                using_dpi = DEFAULT_DPI as f32;
+            }
+
             info!("found dpi: {:?} using dpi: {:?}", dpi, using_dpi);
             dpi_scaling = 1.25 / (96_f32 / using_dpi);
 


### PR DESCRIPTION
Fixes exception in https://github.com/luxtorpeda-dev/luxtorpeda/issues/167

Re-test steam deck and wayland