### PR TITLE
[striezel] update actions used in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       CARGO_HOME: ./cargo
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install SDL 2 Dev
       run: apt update && apt-get install -y libsdl2-dev libsdl2-image-dev
     - name: Build
@@ -38,7 +38,7 @@ jobs:
     - name: Package
       run: make version=${{ needs.setup.outputs.build_number }} luxtorpeda.tar.xz
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: luxtorpeda.tar.xz
         path: ./luxtorpeda.tar.xz
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: luxtorpeda.tar.xz
         path: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       CARGO_HOME: ./cargo
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install SDL 2 Dev
       run: apt update && apt-get install -y libsdl2-dev libsdl2-image-dev
     - name: Build
@@ -19,7 +19,7 @@ jobs:
     - name: Package
       run: make version=${{ github.head_ref }}.${{ github.sha }} luxtorpeda.tar.xz
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: luxtorpeda.tar.xz
         path: ./luxtorpeda.tar.xz
@@ -31,7 +31,7 @@ jobs:
       CARGO_HOME: ./cargo
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install SDL 2 Dev
       run: apt update && apt-get install -y libsdl2-dev libsdl2-image-dev
     - name: Install Clippy
@@ -46,7 +46,7 @@ jobs:
       CARGO_HOME: ./cargo
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install SDL 2 Dev
       run: apt update && apt-get install -y libsdl2-dev libsdl2-image-dev
     - name: Install fmt
@@ -61,7 +61,7 @@ jobs:
       CARGO_HOME: ./cargo
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install SDL 2 Dev
       run: apt update && apt-get install -y libsdl2-dev libsdl2-image-dev
     - name: Install Audit


### PR DESCRIPTION
Updates the actions `actions/checkout`, `actions/upload-artifact`, and `actions/download-artifact` to the newest major release.

As far as I am aware all the changes should be backwards compatible.

### Luxtorpeda Client Submissions

* [x] Have you verified that the code changes in the pull request are related to only the items you wish to change?
* [ ] Have you run the build locally and ensured the changes allowed you to launch and play the Steam game?
* [x] Have you ensured that there is not already a pull request or active feature for the one you are adding?
