### PR TITLE
Remove dependency on steam-vdf and nom = 1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.1",
+ "nom",
 ]
 
 [[package]]
@@ -859,6 +859,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyvalues-serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da419ac133bb3ddf0dbf9c12fcc0ce01d994fcb65f6f1713faf15cc689320b5f"
+dependencies = [
+ "keyvalues-parser",
+ "once_cell",
+ "paste",
+ "regex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,12 +1046,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
-
-[[package]]
-name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
@@ -1129,6 +1137,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pbkdf2"
@@ -1558,25 +1572,14 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "steamlocate"
-version = "0.1.5"
-source = "git+https://github.com/luxtorpeda-dev/steamlocate-rs?tag=0.1.5#db8ad81c6d2759793104b5602cd79d9aabf74c75"
+version = "2.0.0"
+source = "git+https://github.com/WilliamVenner/steamlocate-rs.git?rev=3f1559f#3f1559ffe5b4ef0e892c17d34a2cccf4f3995c9d"
 dependencies = [
- "anyhow",
  "dirs 3.0.2",
  "keyvalues-parser",
- "lazy_static",
- "regex",
- "steamy-vdf",
+ "keyvalues-serde",
+ "serde",
  "winreg",
-]
-
-[[package]]
-name = "steamy-vdf"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533127ad49314bfe71c3d3fd36b3ebac3d24f40618092e70e1cfe8362c7fac79"
-dependencies = [
- "nom 1.2.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ flate2 = "1.0.23"
 futures-util = "0.3.21"
 tokio = { version = "1.24.2", default-features = false, features = ["full"] }
 which = "4.3.0"
-steamlocate = { git = "https://github.com/luxtorpeda-dev/steamlocate-rs", tag = "0.1.5" }
+steamlocate = { git = "https://github.com/WilliamVenner/steamlocate-rs.git", "rev" = "3f1559f" }
 signal-hook = "0.3.14"
 log = "0.4.17"
 simplelog = "0.12.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,7 +101,7 @@ impl LuxClient {
         let status_str = serde_json::to_string(&status_obj).unwrap();
         let emitter = &mut base.get_node("Container/Progress").unwrap();
         let emitter = unsafe { emitter.assume_safe() };
-        emitter.emit_signal("progress_change", &[Variant::new(&status_str)]);
+        emitter.emit_signal("progress_change", &[Variant::new(status_str)]);
     }
 
     #[method]

--- a/src/command.rs
+++ b/src/command.rs
@@ -147,7 +147,7 @@ pub fn run_setup(
         return Err(Error::new(ErrorKind::Other, "setup failed"));
     }
 
-    File::create(&setup_info["complete_path"].to_string())?;
+    File::create(setup_info["complete_path"].to_string())?;
 
     Ok(())
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -220,7 +220,7 @@ pub fn update_packages_json() -> io::Result<()> {
         let local_packages_temp_path =
             path_to_packages_file().with_file_name(std::format!("{}-temp.json", remote_path));
 
-        match reqwest::blocking::get(&remote_packages_url) {
+        match reqwest::blocking::get(remote_packages_url) {
             Ok(mut response) => {
                 let mut dest = fs::File::create(&local_packages_temp_path)?;
                 io::copy(&mut response, &mut dest)?;


### PR DESCRIPTION
Problematic dependency sub-tree was:

```
steamlocate v0.1.5 (https://github.com/luxtorpeda-dev/steamlocate-rs?tag=0.1.5#db8ad81c)
└── steamy-vdf v0.2.0
    └── nom v1.2.4
```
and was causing following warning for every build using Rust 1.68:

> warning: the following packages contain code that will be rejected by a future version of Rust: nom v1.2.4
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 8`

With this change, the build is clean again :smile:.

This is very much related to https://github.com/WilliamVenner/steamlocate-rs/pull/9.

Perhaps we should wait for `steamlocate`  maintainer to release the v2 alpha version to cargo registry, but the fix works fine already. As a bonus, fork https://github.com/luxtorpeda-dev/steamlocate-rs should no longer be necessary (except for reproducing old builds maybe - but the repo could be archived probably).

Tested with UT:GOTY, which tries to locate Steam Runtime (app id 1070560) - worked correctly when runtime was installed and when it was removed.

Also, piggy-backed 3 cargo clippy fixes - now we have clean clippy report :)

<!-- You can remove any parts of this template that do not apply to your changes -->

### Luxtorpeda Client Submissions

* [x] Have you verified that the code changes in the pull request are related to only the items you wish to change?
* [x] Have you run the build locally and ensured the changes allowed you to launch and play the Steam game?
* [x] Have you ensured that there is not already a pull request or active feature for the one you are adding?

