### PR TITLE
Improve actions time - use built godot export & actions to setup environment 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,29 +7,44 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.71-buster
     env:
       CARGO_HOME: ./cargo
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install Deps
-      run: apt-get update && apt-get -y install clang libsdl2-dev scons libpng-dev
-    - name: Cache Godot deps
-      id: cache-godot
-      uses: actions/cache@v3
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
       with:
-        key: ${{ runner.os }}-build-godot351
-        path: |
-          /usr/local/bin/godot
-          ~/.local/share/godot/templates/3.5.2.stable/linux_x11_64_release
+        profile: minimal
+        toolchain: 1.72.0
+    - name: Use rust cache
+      uses: Swatinem/rust-cache@v2
+    - name: Install Deps
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: clang libsdl2-dev
+        version: 1.0
+    - name: Download Godot Export Template
+      uses: robinraju/release-downloader@v1.8
+      with:
+        repository: luxtorpeda-dev/godot_release_template
+        latest: true
+        fileName: "*"
+        tarBall: false
+        zipBall: false
+    - name: Read godot version
+      id: godot_version
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./godot_version.txt
     - name: Install Godot
-      if: steps.cache-godot.outputs.cache-hit != 'true'
-      run: wget https://downloads.tuxfamily.org/godotengine/3.5.2/Godot_v3.5.2-stable_linux_headless.64.zip && unzip Godot_v3.5.2-stable_linux_headless.64.zip && chmod +x Godot_v3.5.2-stable_linux_headless.64 && rm Godot_v3.5.2-stable_linux_headless.64.zip && mv Godot_v3.5.2-stable_linux_headless.64 /usr/local/bin/godot
-    - name: Build Godot Export Template
-      if: steps.cache-godot.outputs.cache-hit != 'true'
-      run: make godot-export-template SCONS="python3 /usr/bin/scons" && mkdir -p ~/.local/share/godot/templates/3.5.2.stable && mv ./godot-build/bin/godot.x11.opt.64 ~/.local/share/godot/templates/3.5.2.stable/linux_x11_64_release
+      uses: paulloz/godot-action@v1.2.2
+      with:
+        version: ${{ steps.godot_version.outputs.content }}
+    - name: Move Godot Export Template
+      run: |
+        mkdir -p ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable
+        mv ./linux_x11_64_release ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable/linux_x11_64_release
     - name: Build
       run: make release GODOT=godot
     - name: Package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: 1.72.0
+      run: |
+        rustup toolchain install 1.72 --profile minimal --no-self-update
+        rustup default 1.72
+      shell: bash
     - name: Use rust cache
       uses: Swatinem/rust-cache@v2
     - name: Install Deps
@@ -37,10 +37,12 @@ jobs:
       uses: juliangruber/read-file-action@v1
       with:
         path: ./godot_version.txt
+        trim: true
     - name: Install Godot
       uses: paulloz/godot-action@v1.2.2
       with:
         version: ${{ steps.godot_version.outputs.content }}
+        export-templates: false
     - name: Move Godot Export Template
       run: |
         mkdir -p ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
       run: |
         rustup toolchain install 1.72 --profile default
         rustup default 1.72
+    - name: Use rust cache
+      uses: Swatinem/rust-cache@v2
     - name: Clippy Run
       run: cargo clippy
   fmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: 1.72.0
+      run: |
+        rustup toolchain install 1.72 --profile minimal --no-self-update
+        rustup default 1.72
+      shell: bash
     - name: Use rust cache
       uses: Swatinem/rust-cache@v2
     - name: Install Deps
@@ -33,13 +33,15 @@ jobs:
       uses: juliangruber/read-file-action@v1
       with:
         path: ./godot_version.txt
+        trim: true
     - name: Install Godot
       uses: paulloz/godot-action@v1.2.2
       with:
         version: ${{ steps.godot_version.outputs.content }}
+        export-templates: false
     - name: Move Godot Export Template
       run: |
-        mkdir -p ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable
+        mkdir -p ~/.local/share/godot/templates/"${{ steps.godot_version.outputs.content }}.stable"
         mv ./linux_x11_64_release ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable/linux_x11_64_release
     - name: Build
       run: make release GODOT=godot
@@ -59,9 +61,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.72.0
+      run: |
+        rustup toolchain install 1.72 --no-self-update
+        rustup default 1.72
     - name: Clippy Run
       run: cargo clippy
   fmt:
@@ -70,9 +72,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.72.0
+      run: |
+        rustup toolchain install 1.72 --no-self-update
+        rustup default 1.72
     - name: fmt Run
       run: cargo fmt --all -- --check
   audit:
@@ -81,12 +83,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.72.0
+      run: |
+        rustup toolchain install 1.72 --no-self-update
+        rustup default 1.72
     - name: Use rust cache
       uses: Swatinem/rust-cache@v2
-    - name: Install Audit
-      run: cargo install cargo-audit
     - name: Audit Run
       run: cargo audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,29 +5,42 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.71-buster
-    env:
-      CARGO_HOME: ./cargo
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install Deps
-      run: apt-get update && apt-get -y install clang libsdl2-dev scons libpng-dev
-    - name: Cache Godot deps
-      id: cache-godot
-      uses: actions/cache@v3
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
       with:
-        key: ${{ runner.os }}-build-godot351
-        path: |
-          /usr/local/bin/godot
-          ~/.local/share/godot/templates/3.5.2.stable/linux_x11_64_release
+        profile: minimal
+        toolchain: 1.72.0
+    - name: Use rust cache
+      uses: Swatinem/rust-cache@v2
+    - name: Install Deps
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: clang libsdl2-dev
+        version: 1.0
+    - name: Download Godot Export Template
+      uses: robinraju/release-downloader@v1.8
+      with:
+        repository: luxtorpeda-dev/godot_release_template
+        latest: true
+        fileName: "*"
+        tarBall: false
+        zipBall: false
+    - name: Read godot version
+      id: godot_version
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./godot_version.txt
     - name: Install Godot
-      if: steps.cache-godot.outputs.cache-hit != 'true'
-      run: wget https://downloads.tuxfamily.org/godotengine/3.5.2/Godot_v3.5.2-stable_linux_headless.64.zip && unzip Godot_v3.5.2-stable_linux_headless.64.zip && chmod +x Godot_v3.5.2-stable_linux_headless.64 && rm Godot_v3.5.2-stable_linux_headless.64.zip && mv Godot_v3.5.2-stable_linux_headless.64 /usr/local/bin/godot
-    - name: Build Godot Export Template
-      if: steps.cache-godot.outputs.cache-hit != 'true'
-      run: make godot-export-template SCONS="python3 /usr/bin/scons" && mkdir -p ~/.local/share/godot/templates/3.5.2.stable && mv ./godot-build/bin/godot.x11.opt.64 ~/.local/share/godot/templates/3.5.2.stable/linux_x11_64_release
+      uses: paulloz/godot-action@v1.2.2
+      with:
+        version: ${{ steps.godot_version.outputs.content }}
+    - name: Move Godot Export Template
+      run: |
+        mkdir -p ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable
+        mv ./linux_x11_64_release ~/.local/share/godot/templates/${{ steps.godot_version.outputs.content }}.stable/linux_x11_64_release
     - name: Build
       run: make release GODOT=godot
     - name: Package
@@ -42,41 +55,37 @@ jobs:
         path: ./luxtorpeda.tar.xz
   clippy:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.71-buster
-    env:
-      CARGO_HOME: ./cargo
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install Deps
-      run: apt-get update && apt-get -y install clang
-    - name: Install Clippy
-      run: rustup component add clippy
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.72.0
     - name: Clippy Run
       run: cargo clippy
   fmt:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.71-buster
-    env:
-      CARGO_HOME: ./cargo
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install fmt
-      run: rustup component add rustfmt
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.72.0
     - name: fmt Run
       run: cargo fmt --all -- --check
   audit:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.71-buster
-    env:
-      CARGO_HOME: ./cargo
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.72.0
+    - name: Use rust cache
+      uses: Swatinem/rust-cache@v2
     - name: Install Audit
       run: cargo install cargo-audit
     - name: Audit Run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Install Rust
       run: |
-        rustup toolchain install 1.72 --no-self-update
+        rustup toolchain install 1.72 --profile default
         rustup default 1.72
     - name: Clippy Run
       run: cargo clippy
@@ -73,7 +73,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Install Rust
       run: |
-        rustup toolchain install 1.72 --no-self-update
+        rustup toolchain install 1.72 --profile default
         rustup default 1.72
     - name: fmt Run
       run: cargo fmt --all -- --check
@@ -84,7 +84,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Install Rust
       run: |
-        rustup toolchain install 1.72 --no-self-update
+        rustup toolchain install 1.72 --profile default
         rustup default 1.72
     - name: Use rust cache
       uses: Swatinem/rust-cache@v2

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ STRIP := strip
 PREFIX := /usr/local
 
 GODOT := ~/.local/share/Steam/steamapps/common/Godot\ Engine/godot.x11.opt.tools.64
-SCONS := scons
 
 install_dir = $(DESTDIR)/$(PREFIX)/share/steam/compatibilitytools.d/$(tool_dir)
 
@@ -113,9 +112,3 @@ user-uninstall:
 
 check-formatting:
 	cargo fmt -- --check
-
-godot-export-template:
-	# scons is needed for this
-	rm -rf godot-build
-	git clone https://github.com/godotengine/godot.git --depth 1 -b 3.5.2-stable godot-build
-	cd godot-build && $(SCONS) platform=x11 production=yes tools=no target=release bits=64 lto=full disable_3d=yes module_arkit_enabled=no module_assimp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no module_recast_enabled=no module_regex_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no module_svg_enabled=no optimize=size minizip=no module_freetype_enabled=no module_gdnavigation_enabled=no module_ogg_enabled=no module_minimp3_enabled=no warnings=no builtin_libpng=no


### PR DESCRIPTION
<!-- You can remove any parts of this template that do not apply to your changes -->

Improve the action build time by using cache and creating a built godot template that can be re-used. As well, updated some of the steps to use actions instead of custom code.

### Luxtorpeda Client Submissions

* [x] Have you verified that the code changes in the pull request are related to only the items you wish to change?
* [x] Have you run the build locally and ensured the changes allowed you to launch and play the Steam game?
* [x] Have you ensured that there is not already a pull request or active feature for the one you are adding?
