### PR TITLE
Have releases contain a proper sha512 checksum file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,18 @@ jobs:
       run: make release GODOT=godot
     - name: Package
       run: make version=${{ github.ref_name }} luxtorpeda.tar.xz GODOT=godot
-    - name: Upload Artifacts
+    - name: Calculate a checksum of release
+      run: sha512sum luxtorpeda.tar.xz > luxtorpeda.tar.xz.sha512
+    - name: Upload Release Artifact
       uses: actions/upload-artifact@v4
       with:
         name: luxtorpeda.tar.xz
         path: ./luxtorpeda.tar.xz
+    - name: Upload Checksum Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: luxtorpeda.tar.xz.sha512
+        path: ./luxtorpeda.tar.xz.sha512
   deploy:
     needs: [build]
     runs-on: ubuntu-latest
@@ -46,8 +53,10 @@ jobs:
       with:
         name: luxtorpeda.tar.xz
         path: ./
-    - name: Rename Artifact for Release Prep
-      run: mv luxtorpeda.tar.xz luxtorpeda-${{ github.ref_name }}.tar.xz
+    - name: Rename Artifacts for Release Prep
+      run: |
+        mv luxtorpeda.tar.xz luxtorpeda-${{ github.ref_name }}.tar.xz
+        mv luxtorpeda.tar.xz.sha512 luxtorpeda-${{ github.ref_name }}.tar.xz.sha512
     - name: Create Release
       id: create_release
       uses: softprops/action-gh-release@v2.0.5
@@ -59,4 +68,6 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          files: luxtorpeda-${{ github.ref_name }}.tar.xz
+          files: |
+            luxtorpeda-${{ github.ref_name }}.tar.xz
+            luxtorpeda-${{ github.ref_name }}.tar.xz.sha512

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,18 @@ jobs:
         SHA_VALUE: ${{ github.sha }}
         HEAD_REF: ${{ github.head_ref }}
       run: make version="$HEAD_REF"."$SHA_VALUE" luxtorpeda.tar.xz GODOT=godot
-    - name: Upload Artifacts
+    - name: Calculate a checksum of release
+      run: sha512sum luxtorpeda.tar.xz > luxtorpeda.tar.xz.sha512
+    - name: Upload Release Artifact
       uses: actions/upload-artifact@v4
       with:
         name: luxtorpeda.tar.xz
         path: ./luxtorpeda.tar.xz
+    - name: Upload Checksum Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: luxtorpeda.tar.xz.sha512
+        path: ./luxtorpeda.tar.xz.sha512
   clippy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I was bothered that you cannot verify the releases checksum. So I modified the github workflow file to allow such.

I implemented this change in both `test` and `build` workflows.
I decided to use the upload artifacts action separately for each artifact file as it seems to me that is what the documentation recommends/suggests.

edit: I also changed the associated step names to reflect exactly what is being done. e.g. `Upload artifacts` -> `Upload release/checksum artifact`