### PR TITLE
workflows: Added a step to fix name in checksum

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
       run: |
         mv luxtorpeda.tar.xz luxtorpeda-${{ github.ref_name }}.tar.xz
         mv luxtorpeda.tar.xz.sha512 luxtorpeda-${{ github.ref_name }}.tar.xz.sha512
+    - name: Update name inside the checksum file
+      run: sed -i 's/luxtorpeda.tar.xz/luxtorpeda-${{ github.ref_name }}.tar.xz/g' luxtorpeda-${{ github.ref_name }}.tar.xz.sha512
     - name: Create Release
       id: create_release
       uses: softprops/action-gh-release@v2.0.6


### PR DESCRIPTION
When creating #364. I somehow missed that the file name `luxtorpeda.tar.xz` gets changed `(to e.g. luxtorpeda-v70.1.1.tar.xz)` when a build is published and simply running `sha512sum -c` does not work properly simply because the filename in checksum file does not contain the version number. The checksum file still contains `luxtorpeda.tar.xz` without the version string.

This should be enough to correct this error. However, It does not feel right to me to edit the file inside the `deploy` job. But I am not sure that it could be done differently now without changing the entire workflow file. :thinking: 