### PR TITLE
Fix Proton cmd path

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -515,15 +515,9 @@ pub fn run_wrapper(
                                 commandline = tool.commandline.clone();
                                 proton_args.push("waitforexitandrun".to_string());
 
-                                let tmp_path = format!(
-                                    "{}/{}",
-                                    PathBuf::from(args[0])
-                                        .parent()
-                                        .unwrap()
-                                        .display()
-                                        .to_string(),
-                                    cmd
-                                );
+                                let tmp_path =
+                                    env::current_dir().unwrap().join(cmd).display().to_string();
+                                info!("launching proton with path to our exe: {}", tmp_path);
                                 proton_args.push(tmp_path); // the original exe
                             }
                         }


### PR DESCRIPTION
This should've fixed the link2ea:// problem for Northstar but ended up finding out we cannot do Northstar at the moment. May still be useful for Venice Unleashed (Battlefield 3) if possible to implement though, wouldn't count on it